### PR TITLE
Added PreserveOperator and fix for Dot paths

### DIFF
--- a/examples/specific.rs
+++ b/examples/specific.rs
@@ -4,50 +4,27 @@ use serde_json::json;
 fn main() {
     let logic = JsonLogic::new();
 
-    let rule = json!({
-        "filter": [
-            {
-                "var": "locales"
-            },
-            {
-                "!==": [
-                    {
-                        "var": "code"
-                    },
-                    {
-                        "var": "../../locale"
-                    }
-                ]
-            }
-        ]
-    });
-    let data = json!({
-        "locale": "pl",
-        "locales": [
-            {
-                "name": "Israel",
-                "code": "he",
-                "flag": "🇮🇱",
-                "iso": "he-IL",
-                "dir": "rtl"
-            },
-            {
-                "name": "українська",
-                "code": "ue",
-                "flag": "🇺🇦",
-                "iso": "uk-UA",
-                "dir": "ltr"
-            },
-            {
-                "name": "Polski",
-                "code": "pl",
-                "flag": "🇵🇱",
-                "iso": "pl-PL",
-                "dir": "ltr"
-            }
-        ]
-    });
-    
-    let result = logic.apply(&rule, &data).unwrap();
-    println!("Result: {}", result);
+    // Test both escaped dot and regular dot navigation
+    let test_cases = vec![
+        // Test 1: Escaped dot should look up exact key
+        (
+            json!({"var": "hello\\.world"}),
+            json!({"hello": {"world": "i'm here!"}, "hello.world": "ups!"}),
+            "ups!"
+        ),
+        // Test 2: Regular dot should navigate nested object
+        (
+            json!({"var": "hello.world"}),
+            json!({"hello": {"world": "i'm here!"}, "hello.world": "ups!"}),
+            "i'm here!"
+        )
+    ];
+
+    for (rule, data, expected) in test_cases {
+        let result = logic.apply(&rule, &data).unwrap();
+        println!("Rule: {}", rule);
+        println!("Result: {}", result);
+        println!("Expected: {}", expected);
+        println!("---");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod error;
 mod operators;
 
 use error::Error;
+use operators::preserve::PreserveOperator;
 use operators::{
     operator::Operator, 
     var::VarOperator, 
@@ -83,6 +84,7 @@ impl JsonLogic {
         self.operators.insert("none".into(), Arc::new(NoneOperator)); 
         self.operators.insert("some".into(), Arc::new(SomeOperator));
  
+        self.operators.insert("preserve".into(), Arc::new(PreserveOperator));
     
     }
 

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -7,3 +7,4 @@ pub mod string;
 pub mod array;
 pub mod missing;
 pub mod array_ops;
+pub mod preserve;

--- a/src/operators/preserve.rs
+++ b/src/operators/preserve.rs
@@ -1,0 +1,20 @@
+use crate::operators::operator::Operator;
+use crate::{Error, JsonLogic, JsonLogicResult};
+use serde_json::Value;
+
+#[derive(Default)]
+pub struct PreserveOperator;
+
+impl Operator for PreserveOperator {
+    fn apply(&self, _logic: &JsonLogic, args: &Value, _data: &Value) -> JsonLogicResult {
+        match args {
+            Value::Object(obj) => Ok(Value::Object(obj.clone())),
+            _ => Err(Error::InvalidArguments("preserve requires object argument".into()))
+        }
+    }
+
+    // Optionally disable auto traversal since we want to preserve the raw value
+    fn auto_traverse(&self) -> bool {
+        false
+    }
+}

--- a/tests/alltests.rs
+++ b/tests/alltests.rs
@@ -78,10 +78,8 @@ fn test_jsonlogic_all_test_suites() {
     let test_sources = vec![
         // Remote URLs
         "https://jsonlogic.com/tests.json",
-        // "https://raw.githubusercontent.com/TotalTechGeek/json-logic-engine/refs/heads/master/bench/tests.json",
-        // "https://raw.githubusercontent.com/TotalTechGeek/json-logic-engine/refs/heads/master/bench/compatible.json",
         // Local file
-        // "tests/custom_tests.json",  // Add your local test file path here
+        "tests/custom_tests.json",  // Add your local test file path here
     ];
 
     let mut overall_passed = 0;

--- a/tests/custom_tests.json
+++ b/tests/custom_tests.json
@@ -1,6 +1,16 @@
 [
     "Custom Tests",
     [
+        {"var": "hello\\.world"},
+        {"hello": {"world": "i'm here!"}, "hello.world": "ups!"},
+        "ups!"
+    ],
+    [
+        {"var": "hello.world"},
+        {"hello": {"world": "i'm here!"}, "hello.world": "ups!"},
+        "i'm here!"
+    ],
+    [
         {
             "var": "hello\\.world"
         },
@@ -57,5 +67,24 @@
             ]
         },
         [{"name":"Israel","code":"he","flag":"🇮🇱","iso":"he-IL","dir":"rtl"},{"name":"українська","code":"ue","flag":"🇺🇦","iso":"uk-UA","dir":"ltr"}]
+    ],
+    [
+        {
+            "if": [
+                {
+                    "and": [
+                        { "===": [ { "var": "first_name" }, true ] },
+                        { "===": [ { "var": "last_name" }, true ] }
+                    ]
+                },
+                { "preserve": { "first_name": "scott", "last_name": "wyatt" } },
+                { "preserve": { "first_name": "no", "last_name": "idea" } }
+            ]
+        }, 
+        {
+            "first_name": true,
+            "last_name": true
+        },
+        {"first_name":"scott","last_name":"wyatt"}
     ]
 ]


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `json-logic-rs` library, including adding a new operator, improving existing functionality, and updating test cases. Here are the most important changes:

### New Operator Addition:
* Added a new `PreserveOperator` to the library, which allows preserving the raw value of an object without auto traversal. This operator has been implemented and registered in the `JsonLogic` struct. (`src/lib.rs`, `src/operators/mod.rs`, `src/operators/preserve.rs`) [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R5) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R87) [[3]](diffhunk://#diff-b4c1172dd870d2fe60c2e9a2168155e1027b367cba4a44970c4c82b2b10e38daR10) [[4]](diffhunk://#diff-d6192c359ecbb9dc1842f0a5b8609e0a74e6979152b04c7ba6b392338eabad5dR1-R20)

### Improvements to `VarOperator`:
* Enhanced the `VarOperator` to handle escaped dot paths and regular dot navigation separately. This allows users to look up exact keys with escaped dots and navigate nested objects with regular dots. (`src/operators/var.rs`) [[1]](diffhunk://#diff-b5d801bfcd4c985d0324ade38d9680e3296e20690cae3af0ca7baee003215dafR14-R34) [[2]](diffhunk://#diff-b5d801bfcd4c985d0324ade38d9680e3296e20690cae3af0ca7baee003215dafL45-L64)

### Test Cases Updates:
* Updated `examples/specific.rs` to include new test cases for both escaped and regular dot navigation. This ensures that the new functionality is properly tested. (`examples/specific.rs`)
* Updated `tests/custom_tests.json` to include new test cases for the `PreserveOperator` and enhanced `VarOperator`. This helps verify the correctness of the new operator and improvements. (`tests/custom_tests.json`) [[1]](diffhunk://#diff-2dc19c3f0a44b8f0501fcdbe3c196e2c013d8d1abb2743e247328ebc9c7d5fbcR3-R12) [[2]](diffhunk://#diff-2dc19c3f0a44b8f0501fcdbe3c196e2c013d8d1abb2743e247328ebc9c7d5fbcR70-R88)

### Miscellaneous:
* Enabled a previously commented-out local test file path in `tests/alltests.rs`, allowing for custom local tests to be easily added and executed. (`tests/alltests.rs`)