### PR TITLE
Slight performance improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ criterion = "0.5"
 lazy_static = "1.4"
 reqwest = { version = "0.11", features = ["blocking"] }
 
-
 [[bench]]
 name = "jsonlogic_bench"
 harness = false

--- a/benches/jsonlogic_bench.rs
+++ b/benches/jsonlogic_bench.rs
@@ -33,7 +33,11 @@ lazy_static::lazy_static! {
 fn bench_apply_all_rules(c: &mut Criterion) {
     let logic = JsonLogic::new();
     
-    c.bench_function("apply_all_rules", |b| {
+    let mut group = c.benchmark_group("jsonlogic_rules");
+    group.sampling_mode(criterion::SamplingMode::Linear);
+    group.sample_size(50);
+    
+    group.bench_function("apply_all_rules", |b| {
         b.iter(|| {
             for (rule, data, expected) in TEST_CASES.iter() {
                 if let Ok(result) = logic.apply(rule, data) {
@@ -42,7 +46,13 @@ fn bench_apply_all_rules(c: &mut Criterion) {
             }
         })
     });
+    
+    group.finish();
 }
 
-criterion_group!(benches, bench_apply_all_rules);
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = bench_apply_all_rules
+);
 criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,11 +113,10 @@ impl JsonLogic {
                 }
             }
             Value::Array(values) => {
-                // Recursively evaluate each array element
-                let results = values
-                    .iter()
-                    .map(|v| self.apply(v, data))
-                    .collect::<Result<Vec<_>, _>>()?;
+                let mut results = Vec::with_capacity(values.len());
+                for v in values {
+                    results.push(self.apply(v, data)?);
+                }
                 Ok(Value::Array(results))
             }
             Value::String(_) | Value::Number(_) | Value::Bool(_) | Value::Null => {

--- a/src/operators/array_ops.rs
+++ b/src/operators/array_ops.rs
@@ -1,4 +1,3 @@
-// src/operators/array_ops.rs
 use crate::operators::operator::Operator;
 use crate::{JsonLogic, JsonLogicResult};
 use serde_json::{json, Value};
@@ -79,18 +78,21 @@ impl Operator for MapOperator {
     fn apply(&self, logic: &JsonLogic, args: &Value, data: &Value) -> JsonLogicResult {
         let (source, mapper) = match Self::validate_args(args) {
             Some(args) => args,
-            None => return Ok(Value::Array(vec![])),
+            None => return Ok(Value::Array(Vec::new())),
         };
 
         let array = match logic.apply(source, data)? {
             Value::Array(arr) => arr,
-            _ => return Ok(Value::Array(vec![])),
+            _ => return Ok(Value::Array(Vec::new())),
         };
 
-        let result = array
-            .into_iter()
-            .map(|item| logic.apply(mapper, &item))
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut result = Vec::with_capacity(array.len());
+        result.extend(
+            array
+                .into_iter()
+                .map(|item| logic.apply(mapper, &item))
+                .collect::<Result<Vec<_>, _>>()?
+        );
 
         Ok(Value::Array(result))
     }

--- a/src/operators/var.rs
+++ b/src/operators/var.rs
@@ -1,4 +1,3 @@
-// src/operators/var.rs
 use crate::operators::operator::Operator;
 use crate::{JsonLogic, JsonLogicResult};
 use serde_json::Value;
@@ -9,6 +8,22 @@ impl VarOperator {
     pub(crate) fn get_value_at_path(data: &Value, path: &str) -> Option<Value> {
         if path.is_empty() {
             return Some(data.clone());
+        }
+
+        // Handle direct array access with numeric string
+        if let Ok(index) = path.parse::<usize>() {
+            if let Value::Array(arr) = data {
+                return arr.get(index).cloned();
+            }
+            return None;
+        }
+        
+        // Avoid allocation for single-level paths
+        if !path.contains('.') {
+            if let Value::Object(map) = data {
+                return map.get(path).cloned();
+            }
+            return None;
         }
 
         // Handle escaped path first


### PR DESCRIPTION
This pull request includes several enhancements and optimizations to the benchmarking and JSON logic application code. The most important changes include improvements to the benchmarking setup, optimizations in array handling, and enhancements to the `VarOperator`.

### Benchmarking Enhancements:
* [`benches/jsonlogic_bench.rs`](diffhunk://#diff-cf4c34eb1a3822a008251c0f253e802f51caeb95eaccea7691cda954e914e8f4L36-R40): Added a benchmark group with linear sampling mode and a sample size of 50. This change helps in better organizing and controlling the benchmarks. [[1]](diffhunk://#diff-cf4c34eb1a3822a008251c0f253e802f51caeb95eaccea7691cda954e914e8f4L36-R40) [[2]](diffhunk://#diff-cf4c34eb1a3822a008251c0f253e802f51caeb95eaccea7691cda954e914e8f4R49-R57)

### Array Handling Optimizations:
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L116-R119): Optimized the handling of array elements by pre-allocating the vector capacity and using a for loop instead of iterators for better performance.
* [`src/operators/array_ops.rs`](diffhunk://#diff-4ef6b9037620f19522f644c1625afbd5ff052c963d55600b0d0ae310b3e9b151L82-R95): Replaced the creation of empty vectors with `Vec::new()` and pre-allocated vector capacity for better performance.

### VarOperator Enhancements:
* [`src/operators/var.rs`](diffhunk://#diff-b5d801bfcd4c985d0324ade38d9680e3296e20690cae3af0ca7baee003215dafR13-R28): Added support for direct array access using numeric strings and optimized single-level path access to avoid unnecessary allocations.

### Minor Changes:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L26): Removed an unnecessary empty line.
* [`src/operators/array_ops.rs`](diffhunk://#diff-4ef6b9037620f19522f644c1625afbd5ff052c963d55600b0d0ae310b3e9b151L1): Removed an unnecessary comment line.
* [`src/operators/var.rs`](diffhunk://#diff-b5d801bfcd4c985d0324ade38d9680e3296e20690cae3af0ca7baee003215dafL1): Removed an unnecessary comment line.