### PR TITLE
Performance improvements

### DIFF
--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -110,6 +110,7 @@ pub enum Rule {
 }
 
 impl Rule {
+    #[inline(always)]
     fn is_static(&self) -> bool {
         match self {
             Rule::Value(_) => true,
@@ -158,6 +159,7 @@ impl Rule {
         }
     }
 
+    #[inline]
     fn optimize_args(args: &[Rule]) -> Result<Vec<Rule>, Error> {
         args.iter()
             .cloned()
@@ -165,6 +167,7 @@ impl Rule {
             .collect()
     }
 
+    #[inline]
     fn rebuild_with_args(rule: Rule, optimized: Vec<Rule>) -> Rule {
         match rule {
             Rule::Map(_) => Rule::Map(optimized),
@@ -206,6 +209,7 @@ impl Rule {
         }
     }
 
+    #[inline]
     fn optimize_rule(rule: Rule) -> Result<Rule, Error> {
         match rule {
             // Never optimize these
@@ -348,6 +352,7 @@ impl Rule {
         }
     }
 
+    #[inline(always)]
     pub fn apply(&self, data: &Value) -> Result<Value, Error> {
         match self {
             Rule::Value(value) => {

--- a/src/rule/operators/control.rs
+++ b/src/rule/operators/control.rs
@@ -52,7 +52,6 @@ impl Operator for IfOperator {
 }
 
 impl Operator for TernaryOperator {
-    #[inline]
     fn apply(&self, args: &[Rule], data: &Value) -> Result<Value, Error> {
         match args {
             [condition, consequent, alternative] => {

--- a/src/rule/operators/logic.rs
+++ b/src/rule/operators/logic.rs
@@ -9,7 +9,6 @@ pub struct DoubleBangOperator;
 
 
 impl Operator for OrOperator {
-    #[inline]
     fn apply(&self, args: &[Rule], data: &Value) -> Result<Value, Error> {
         match args.len() {
             0 => Ok(Value::Bool(false)),
@@ -28,7 +27,6 @@ impl Operator for OrOperator {
 }
 
 impl Operator for AndOperator {
-    #[inline]
     fn apply(&self, args: &[Rule], data: &Value) -> Result<Value, Error> {
         match args.len() {
             0 => Ok(Value::Bool(true)),
@@ -47,7 +45,6 @@ impl Operator for AndOperator {
 }
 
 impl Operator for NotOperator {
-    #[inline]
     fn apply(&self, args: &[Rule], data: &Value) -> Result<Value, Error> {
         match args.len() {
             0 => Ok(Value::Bool(true)),
@@ -64,7 +61,6 @@ impl Operator for NotOperator {
 }
 
 impl Operator for DoubleBangOperator {
-    #[inline]
     fn apply(&self, args: &[Rule], data: &Value) -> Result<Value, Error> {
         match args.len() {
             0 => Ok(Value::Bool(false)),

--- a/src/rule/operators/missing.rs
+++ b/src/rule/operators/missing.rs
@@ -10,7 +10,6 @@ pub struct MissingOperator;
 pub struct MissingSomeOperator;
 
 impl MissingOperator {
-    #[inline]
     fn process_keys(value: Value) -> Vec<String> {
         match value {
             Value::String(s) => vec![s],
@@ -30,7 +29,6 @@ impl MissingOperator {
         }
     }
 
-    #[inline]
     fn check_path(data: &Value, path: &str) -> bool {
         let mut current = data;
         

--- a/src/rule/operators/string.rs
+++ b/src/rule/operators/string.rs
@@ -10,7 +10,6 @@ pub struct CatOperator;
 pub struct SubstrOperator;
 
 impl Operator for InOperator {
-    #[inline]
     fn apply(&self, args: &[Rule], data: &Value) -> Result<Value, Error> {
         if args.len() != 2 {
             return Err(Error::InvalidArguments(ERR_IN.into()));
@@ -28,7 +27,6 @@ impl Operator for InOperator {
 }
 
 impl Operator for CatOperator {
-    #[inline]
     fn apply(&self, args: &[Rule], data: &Value) -> Result<Value, Error> {
         // Fast paths
         match args.len() {

--- a/src/rule/operators/var.rs
+++ b/src/rule/operators/var.rs
@@ -43,7 +43,6 @@ const ERR_INVALID_INDEX: &str = "Invalid array index: ";
 const ERR_INVALID_PATH: &str = "Invalid path";
 
 impl VarOperator {
-    #[inline]
     fn get_value_ref<'a>(&self, data: &'a Value, path: &str) -> Result<&'a Value, Error> {
         // Fast path for empty or root path
         if path.is_empty() {


### PR DESCRIPTION
This pull request includes several optimizations and refactorings in the `src/rule` directory. The changes focus on improving performance by adding inline annotations and simplifying the logic in various operator implementations.

### Performance Improvements:
* [`src/rule/mod.rs`](diffhunk://#diff-61f42884ea206d910232742c9e1a32a5c66009922f3da171bdd8446f952d8a24R113): Added `#[inline(always)]` and `#[inline]` annotations to several methods in the `Rule` enum to improve performance by hinting the compiler to inline these methods. [[1]](diffhunk://#diff-61f42884ea206d910232742c9e1a32a5c66009922f3da171bdd8446f952d8a24R113) [[2]](diffhunk://#diff-61f42884ea206d910232742c9e1a32a5c66009922f3da171bdd8446f952d8a24R162-R170) [[3]](diffhunk://#diff-61f42884ea206d910232742c9e1a32a5c66009922f3da171bdd8446f952d8a24R212) [[4]](diffhunk://#diff-61f42884ea206d910232742c9e1a32a5c66009922f3da171bdd8446f952d8a24R355)

### Operator Logic Simplifications:
* [`src/rule/operators/array.rs`](diffhunk://#diff-8a5cce6855285972022c3eb6de55b8e9c897c3d305d2f247476e105f41b70d4fR57-R86): Refactored the `ReduceOperator` to use static keys for repeated allocations and simplified the handling of array elements to improve performance and readability.
* [`src/rule/operators/comparison.rs`](diffhunk://#diff-d4ec5b613017f9c9a3f3326a03ff0ccb596f27885a4397b260764f3086136b16L17-R228): Simplified the logic for comparison operators (`EqualsOperator`, `StrictEqualsOperator`, `NotEqualsOperator`, `StrictNotEqualsOperator`, `GreaterThanOperator`, `LessThanOperator`, `LessThanEqualOperator`, `GreaterThanEqualOperator`) to handle multiple arguments and improve readability.
* [`src/rule/operators/control.rs`](diffhunk://#diff-37f9afc3d1e7ce066a2c20aa6e9e329d27c85fd4e2d22fe08e8cd7796bcf8267L55): Removed unnecessary `#[inline]` annotation from the `TernaryOperator` implementation.
* [`src/rule/operators/logic.rs`](diffhunk://#diff-32c9c07d1e0e31334cd5f10ea0fa50004f5e1e40a89deee6c9ca8a34ead855deL12): Removed unnecessary `#[inline]` annotations from logical operators (`OrOperator`, `AndOperator`, `NotOperator`, `DoubleBangOperator`) to clean up the code. [[1]](diffhunk://#diff-32c9c07d1e0e31334cd5f10ea0fa50004f5e1e40a89deee6c9ca8a34ead855deL12) [[2]](diffhunk://#diff-32c9c07d1e0e31334cd5f10ea0fa50004f5e1e40a89deee6c9ca8a34ead855deL31) [[3]](diffhunk://#diff-32c9c07d1e0e31334cd5f10ea0fa50004f5e1e40a89deee6c9ca8a34ead855deL50) [[4]](diffhunk://#diff-32c9c07d1e0e31334cd5f10ea0fa50004f5e1e40a89deee6c9ca8a34ead855deL67)
* [`src/rule/operators/missing.rs`](diffhunk://#diff-0615ce3c787e32150de8195045dc30bcef8a7e3bb3ac1b9a01e54c0e6386ccbfL13): Removed unnecessary `#[inline]` annotations from methods in the `MissingOperator` implementation to clean up the code. [[1]](diffhunk://#diff-0615ce3c787e32150de8195045dc30bcef8a7e3bb3ac1b9a01e54c0e6386ccbfL13) [[2]](diffhunk://#diff-0615ce3c787e32150de8195045dc30bcef8a7e3bb3ac1b9a01e54c0e6386ccbfL33)
* [`src/rule/operators/string.rs`](diffhunk://#diff-601fbe46d376469f6f8210c64e7e1a8ddf8ea3c7549859182804ac3284ad37fdL13): Removed unnecessary `#[inline]` annotations from string operators (`InOperator`, `CatOperator`) to clean up the code. [[1]](diffhunk://#diff-601fbe46d376469f6f8210c64e7e1a8ddf8ea3c7549859182804ac3284ad37fdL13) [[2]](diffhunk://#diff-601fbe46d376469f6f8210c64e7e1a8ddf8ea3c7549859182804ac3284ad37fdL31)
* [`src/rule/operators/var.rs`](diffhunk://#diff-a9cd019e83e5a660d2926da1f330d60b752f2b9f2bb4459887b93a0abf5497c9L46): Removed unnecessary `#[inline]` annotation from the `get_value_ref` method in `VarOperator` to clean up the code.