### PR TITLE
fix: remove unconditional chrono/wasmbind from wasm32 target dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4.43", default-features = false, features = ["std", "clo
 regex = { version = "1.12.3", default-features = false, features = ["std", "perf", "unicode"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-chrono = { version = "0.4.43", default-features = false, features = ["std", "clock", "wasmbind"] }
+chrono = { version = "0.4.43", default-features = false, features = ["std", "clock"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
The wasm32 target dependency block unconditionally enabled chrono/wasmbind, pulling in js-sys and wasm-bindgen and generating browser-specific WASM imports (__wbg_new, __wbg_getTime, etc.) that break all server-side WASM runtimes (wasmtime, Chicory, wazero, wasmer).

The 'wasm' feature already exists for users who want chrono/wasmbind in browser environments. Remove it from the unconditional target block so that server-side WASM consumers are not broken.

Fixes: https://github.com/GoPlasmatic/datalogic-rs/issues/47