### PR TITLE
fix(ci): wire UI's WASM dep via file:// for docs.yml build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,25 +75,16 @@ jobs:
           # `npm install`, but isn't checked in. Add `cache: 'npm'` once
           # a lockfile is committed.
 
-      # Pin the UI's `@goplasmatic/datalogic-wasm` dep to the version we just
-      # built in `bindings/wasm/pkg/` (extracted from
-      # `crates/datalogic-rs/Cargo.toml`). Without this the local link below
-      # would mismatch ui/package.json's pin and `npm install`
-      # would replace the symlink with the registry copy. docs.yml doesn't
-      # publish, so this in-memory edit is build-only.
-      - name: Pin UI -> WASM version to local build
-        run: |
-          VERSION=$(grep '^version = ' crates/datalogic-rs/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          cd ui && npm pkg set "dependencies.@goplasmatic/datalogic-wasm=$VERSION"
-
-      # Wire the freshly-built local WASM into ui/node_modules
-      # BEFORE `npm install`. With the symlink already present and its
-      # version matching ui/package.json's pin, `npm install`
-      # preserves it instead of fetching the registry copy.
-      - name: Link local WASM package into UI
-        run: |
-          cd bindings/wasm/pkg && npm link
-          cd ../../../ui && npm link @goplasmatic/datalogic-wasm
+      # Wire the freshly-built local WASM as a `file:` dep so `npm install`
+      # installs it from disk instead of the registry. The published
+      # version may not exist yet (release tag fires later in the v5.0.0
+      # cycle), and the previous `npm link` + version-pin dance proved
+      # fragile: tsc -b couldn't resolve types through the symlink, so
+      # the docs UI build (which runs `tsc -b && vite build`) failed even
+      # though CI's `npm run build:lib` (vite-only) passed. docs.yml
+      # doesn't publish, so this in-memory edit is build-only.
+      - name: Wire local WASM into ui/package.json as a file: dep
+        run: cd ui && npm pkg set "dependencies.@goplasmatic/datalogic-wasm=file:../bindings/wasm/pkg"
 
       - name: Install UI dependencies
         run: cd ui && npm install


### PR DESCRIPTION
## Summary

- The post-v5.0.0-merge `Deploy Documentation` run failed at `Build UI demo`: `tsc` couldn't resolve `@goplasmatic/datalogic-wasm` through the `npm link` symlink.
- CI's `ui-build` job uses the same link recipe but runs `npm run build:lib` (vite only, no tsc), so it never exercised type resolution and missed the regression.
- Replace the `npm link` + version-pin dance with a `file:` dep — npm installs the local pkg as a real package tree (with `.d.ts` and `exports`), eliminating the symlink path entirely.

## Why this happened post-merge, not in PR CI

`docs.yml` runs only on `push: branches: [main]` with paths under `docs/**`, `ui/**`, `bindings/wasm/**`. The v5 PR was the first time the v5-era UI codebase exercised this workflow. PR CI's `ui-build` job runs `lint` + `build:lib` (vite-only) so the tsc gap was invisible.

## Test plan

- [x] Reproduced locally and confirmed `cd ui && npm run build` (tsc -b && vite build) fails with the pre-fix recipe and passes with the file: dep.
- [ ] `Deploy Documentation` workflow green on this PR.

## Risk

- `docs.yml` is build-only (no publish). The `npm pkg set` edit is in-CI and ephemeral.
- No effect on release-publish workflows, which run only on tag push.